### PR TITLE
Respect keywords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.pyc
+*.egg
+*.egg-info

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -68,6 +68,20 @@ class TestExtract(unittest.TestCase):
         self.assertEqual(string[1], '_')  # Function name
         self.assertEqual(string[2], "Test String")  # Translatable string
 
+    def test_custom_keyword_extract(self):
+        template = StringIO("""
+        {{ _C("Test String") }}
+        {{ something }}
+        {% block something %}{% end %}
+        """)
+        strings = list(extract_tornado(template, ('_C', ), None, {}))
+        self.assertEqual(len(strings), 1)
+
+        # Ensure that the string is correct
+        string, = strings
+        self.assertEqual(string[0], 2)  # Line number
+        self.assertEqual(string[1], '_C')  # Custom function name
+        self.assertEqual(string[2], "Test String")  # Translatable string
 
 if __name__ == "__main__":
     unittest.main()

--- a/tornadobabel/extract.py
+++ b/tornadobabel/extract.py
@@ -117,7 +117,7 @@ def extract_tornado(fileobj, keywords, comment_tags, options):
 
     for node in walk(template.file):
         if isinstance(node, _Expression):
-            for lineno, func, message in extract_from_node(node):
+            for lineno, func, message in extract_from_node(node, keywords):
                 # TODO: Implement the comment feature, right now an empty 
                 # iterable is returned
                 yield lineno, func, message, []


### PR DESCRIPTION
Currently keywords from babel are totally ignored.
They are always equal to `tornadobabel.extract.GETTEXT_FUNCTIONS`.
This pull request fix it. Test is also created.
